### PR TITLE
Sync mix project version with app version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Hooks.Mixfile do
 
   def project do
     [app: :hooks,
-     version: "1.2.0",
+     version: "2.0.1",
      description: "Generic plugin & hook system",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Right now mix complains:

```
Unchecked dependencies for environment dev:
* hooks (Hex package)
  the dependency does not match the requirement "2.0.1", got "1.2.0"
** (Mix) Can't continue due to errors on dependencies

```