### PR TITLE
Fix warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule Hooks.Mixfile do
      description: "Generic plugin & hook system",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   def application do


### PR DESCRIPTION
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
[..]/deps/hooks/mix.exs:10: Hooks.Mixfile.project/0

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
 [..]/deps/hooks/mix.exs:11: Hooks.Mixfile.project/0
```